### PR TITLE
Fixed iOS & Android Build Error

### DIFF
--- a/Source/Pages.Code/PopupsPage.cs
+++ b/Source/Pages.Code/PopupsPage.cs
@@ -283,7 +283,6 @@ namespace Forms9PatchDemo.Pages.Code
             var showVerticalTargetedMenu = new Forms9Patch.Button("Vertical TargetedMenu") { BackgroundColor = Color.White };
             var verticalTargetedMenu = new Forms9Patch.TargetedMenu(showVerticalTargetedMenu)
             {
-                Orientation = StackOrientation.Vertical,
                 Segments =
                 {
                     new Segment("Copy", "<font face=\"Forms9PatchDemo.Resources.Fonts.MaterialIcons-Regular.ttf\">&#xE14D;</font>"),


### PR DESCRIPTION
* Fixed the build error as mentioned in Issue #7
* The Orientation Property is not contained in the class anymore
* Removing the line fixed the issue for users trying to test the sample

**Testing**
----
* Tested on iOS Simulator & Android device
* Open the PopupsPage on both devices and made sure the buttons on the page function